### PR TITLE
Fix pytest coverage reporting configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,31 @@
+[run]
+source = app
+omit = 
+    */venv/*
+    */env/*
+    */tests/*
+    */migrations/*
+    app/__init__.py
+    */site-packages/*
+    */__pycache__/*
+    */templates/*
+    */static/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    class .*\bProtocol\):
+    @(abc\.)?abstractmethod
+
+[html]
+directory = htmlcov
+
+[xml]
+output = coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.pytest_cache
 .coverage
 /htmlcov
+/coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+# Makefile for auth project
+
+.PHONY: install test test-cov test-html test-xml clean help
+
+# Default target
+help:
+	@echo "Available targets:"
+	@echo "  install     - Install dependencies"
+	@echo "  test        - Run tests without coverage"
+	@echo "  test-cov    - Run tests with coverage (default reports)"
+	@echo "  test-html   - Run tests and generate HTML coverage report"
+	@echo "  test-xml    - Run tests and generate XML coverage report"
+	@echo "  clean       - Clean coverage files and cache"
+	@echo "  help        - Show this help message"
+
+# Install dependencies
+install:
+	pip install -r requirements.txt
+	pip install -r requirements-pytest.txt
+
+# Run tests without coverage
+test:
+	python -m pytest tests/ -v
+
+# Run tests with coverage (all reports)
+test-cov:
+	python -m pytest tests/ --cov=app --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov-report=term-missing -v
+
+# Run tests and generate HTML coverage report
+test-html:
+	python -m pytest tests/ --cov=app --cov-report=html:htmlcov -v
+
+# Run tests and generate XML coverage report  
+test-xml:
+	python -m pytest tests/ --cov=app --cov-report=xml:coverage.xml -v
+
+# Clean coverage files and cache
+clean:
+	rm -rf htmlcov/
+	rm -f coverage.xml
+	rm -f .coverage
+	rm -rf .pytest_cache/
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,171 @@
+# Testing Guide
+
+This document explains how to run tests and generate coverage reports for the authentication system.
+
+## Prerequisites
+
+Install testing dependencies:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-pytest.txt
+```
+
+## Running Tests
+
+### Option 1: Using Make Commands (Recommended)
+
+```bash
+# Run tests with full coverage reporting
+make test-cov
+
+# Run tests without coverage
+make test
+
+# Generate only HTML coverage report
+make test-html
+
+# Generate only XML coverage report
+make test-xml
+
+# Clean coverage files
+make clean
+
+# Show all available commands
+make help
+```
+
+### Option 2: Using Python Script
+
+```bash
+# Run tests with full coverage reporting
+python run_tests.py
+
+# Run tests without coverage
+python run_tests.py --no-cov
+
+# Generate only HTML coverage report
+python run_tests.py --html
+
+# Generate only XML coverage report
+python run_tests.py --xml
+```
+
+### Option 3: Using pytest Directly
+
+```bash
+# Run tests with coverage (uses pytest.ini configuration)
+pytest
+
+# Run tests with specific coverage options
+pytest --cov=app --cov-report=html --cov-report=term-missing
+
+# Run tests without coverage
+pytest tests/ --no-cov
+```
+
+## Coverage Reports
+
+The testing setup generates multiple types of coverage reports:
+
+### Terminal Report
+Shows coverage summary in the terminal with missing line numbers.
+
+### HTML Report
+- **Location**: `htmlcov/index.html`
+- **Usage**: Open in browser to see detailed coverage with highlighted source code
+- **Features**: Line-by-line coverage visualization, sortable by coverage percentage
+
+### XML Report
+- **Location**: `coverage.xml`
+- **Usage**: For CI/CD systems and tools that parse XML coverage reports
+- **Format**: Cobertura-compatible XML
+
+## Configuration Files
+
+### pytest.ini
+- Pytest configuration with coverage settings
+- Sets coverage threshold to 80% (configurable)
+- Defines test discovery patterns
+- Excludes deprecation warnings
+
+### .coveragerc
+- Coverage.py configuration
+- Defines source paths (`app/` directory)
+- Excludes test files, migrations, templates from coverage
+- Configures report output locations
+
+### tests/conftest.py
+- Flask app test fixtures
+- Database setup for testing
+- Application context management
+
+## Writing Tests
+
+### Test File Location
+Place test files in the `tests/` directory with the naming pattern `test_*.py`.
+
+### Basic Test Structure
+```python
+def test_something(client):
+    """Test description."""
+    response = client.get('/api/endpoint')
+    assert response.status_code == 200
+```
+
+### Available Fixtures
+- `app`: Flask application instance with testing configuration
+- `client`: Test client for making HTTP requests
+- `runner`: CLI runner for testing commands
+- `app_context`: Application context for database operations
+
+### Example Test
+```python
+def test_user_registration(client):
+    """Test user registration endpoint."""
+    response = client.post('/api/auth/register', json={
+        'username': 'testuser',
+        'email': 'test@example.com',
+        'password': 'securepassword123'
+    })
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['message'] == 'User registered successfully'
+```
+
+## Coverage Goals
+
+- **Minimum Coverage**: 80% (enforced by pytest configuration)
+- **Target Coverage**: 90%+ for critical modules (auth, security, encryption)
+- **Files to Focus On**: 
+  - `app/auth/` - Authentication logic
+  - `app/security/` - Security features
+  - `app/utils/encryption.py` - Encryption functions
+  - `app/models/` - Database models
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Import Errors**: Ensure all dependencies are installed
+2. **Database Errors**: Tests use in-memory SQLite; no setup required
+3. **Coverage Too Low**: Add tests for uncovered code paths
+4. **Missing Test Dependencies**: Run `pip install -r requirements-pytest.txt`
+
+### Debug Mode
+Run tests with verbose output:
+```bash
+pytest -v -s tests/
+```
+
+### Running Specific Tests
+```bash
+# Run specific test file
+pytest tests/test_encryption.py
+
+# Run specific test function
+pytest tests/test_encryption.py::test_encrypt_decrypt_basic
+
+# Run tests matching pattern
+pytest -k "encryption"
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,16 @@
+[tool:pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = 
+    --cov=app
+    --cov-report=html:htmlcov
+    --cov-report=xml:coverage.xml
+    --cov-report=term-missing
+    --cov-fail-under=80
+    --strict-markers
+    --tb=short
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Script to run pytest with coverage reporting.
+
+Usage:
+    python run_tests.py              # Run all tests with coverage
+    python run_tests.py --html       # Generate HTML coverage report only
+    python run_tests.py --xml        # Generate XML coverage report only
+    python run_tests.py --no-cov     # Run tests without coverage
+"""
+
+import sys
+import subprocess
+import os
+
+
+def run_command(cmd):
+    """Run a command and return success status."""
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd)
+    return result.returncode == 0
+
+
+def main():
+    """Main function to run pytest with various options."""
+    # Change to the project directory
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    
+    # Base pytest command
+    cmd = ["python", "-m", "pytest"]
+    
+    # Parse simple arguments
+    if "--no-cov" in sys.argv:
+        # Run tests without coverage
+        cmd.extend(["tests/", "-v"])
+    elif "--html" in sys.argv:
+        # Generate only HTML coverage report
+        cmd.extend([
+            "tests/",
+            "--cov=app",
+            "--cov-report=html:htmlcov",
+            "--no-cov-report"
+        ])
+    elif "--xml" in sys.argv:
+        # Generate only XML coverage report
+        cmd.extend([
+            "tests/",
+            "--cov=app", 
+            "--cov-report=xml:coverage.xml",
+            "--no-cov-report"
+        ])
+    else:
+        # Default: run with all coverage reports
+        cmd.extend([
+            "tests/",
+            "--cov=app",
+            "--cov-report=html:htmlcov",
+            "--cov-report=xml:coverage.xml", 
+            "--cov-report=term-missing",
+            "-v"
+        ])
+    
+    # Run the command
+    success = run_command(cmd)
+    
+    if success:
+        print("\n✅ Tests completed successfully!")
+        if "--no-cov" not in sys.argv:
+            print("📊 Coverage reports generated:")
+            if os.path.exists("htmlcov/index.html"):
+                print(f"  - HTML: file://{os.path.abspath('htmlcov/index.html')}")
+            if os.path.exists("coverage.xml"):
+                print(f"  - XML: {os.path.abspath('coverage.xml')}")
+    else:
+        print("\n❌ Tests failed!")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+"""
+Test configuration and fixtures for the Flask application.
+"""
+
+import pytest
+import os
+import tempfile
+from app import create_app
+from app.models import db
+
+
+@pytest.fixture
+def app():
+    """Create and configure a new app instance for each test."""
+    # Create a temporary file to serve as the database
+    db_fd, db_path = tempfile.mkstemp()
+    
+    app = create_app('testing')
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
+    app.config['SECRET_KEY'] = 'test-secret-key'
+    app.config['WTF_CSRF_ENABLED'] = False
+    
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.drop_all()
+    
+    os.close(db_fd)
+    os.unlink(db_path)
+
+
+@pytest.fixture
+def client(app):
+    """A test client for the app."""
+    return app.test_client()
+
+
+@pytest.fixture
+def runner(app):
+    """A test runner for the app's Click commands."""
+    return app.test_cli_runner()
+
+
+@pytest.fixture
+def app_context(app):
+    """Create an application context."""
+    with app.app_context():
+        yield app

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,35 @@
+"""
+Basic tests for the Flask application setup and routing.
+"""
+
+import pytest
+from app import create_app
+
+
+def test_config():
+    """Test that the testing configuration is being used."""
+    assert not create_app('testing').testing
+    app = create_app('testing')
+    assert app.config['TESTING']
+
+
+def test_ping_route(client):
+    """Test the ping route returns expected response."""
+    response = client.get('/ping')
+    assert response.status_code == 200
+    assert response.data == b'Pong!'
+
+
+def test_app_context(app_context):
+    """Test that app context is working."""
+    from flask import current_app
+    assert current_app.config['TESTING']
+
+
+def test_database_connection(app_context):
+    """Test that database connection works."""
+    from app.models import db
+    
+    # Try a simple database operation
+    result = db.engine.execute('SELECT 1 as test').fetchone()
+    assert result['test'] == 1


### PR DESCRIPTION
This PR fixes the pytest coverage reporting by adding proper configuration files and test infrastructure.

## Changes
- Add pytest.ini with coverage settings and 80% threshold
- Add .coveragerc with proper source paths and exclusions
- Update tests/conftest.py with Flask app test fixtures
- Add tests/test_app.py with basic app tests
- Add run_tests.py script for easy test execution
- Add Makefile with convenient test commands
- Add TESTING.md with comprehensive testing guide
- Update .gitignore to exclude coverage.xml

Users can now run `make test-cov` or `python run_tests.py` to generate HTML, XML, and terminal coverage reports.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)